### PR TITLE
“in-text citation” 应翻译为“文内引注”

### DIFF
--- a/src/.vitepress/theme/components/StyleDetails.vue
+++ b/src/.vitepress/theme/components/StyleDetails.vue
@@ -26,7 +26,7 @@ const downloadLinks = {
   keleAzure: `https://oss.wwang.de/styles/src/${style?.dir}/${style?.file}`,
 }
 
-const styleClass = style?.style_class === 'in-text' ? '行间引注' : '脚注'
+const styleClass = style?.style_class === 'in-text' ? '文内引注' : '脚注'
 
 const styleFormatMap: { [key: string]: string } = {
   'author': '著者',


### PR DESCRIPTION
“in-text citation” 应翻译为“文内引注”，区别于 note（注释，包括脚注和尾注）样式。

参考 <https://translate.google.com/?sl=auto&tl=zh-CN&text=in-text%20citation&op=translate>。